### PR TITLE
Add “Always on Top” Window Menu Option with Persistent Preference

### DIFF
--- a/Minesweeper/Defaults.swift
+++ b/Minesweeper/Defaults.swift
@@ -1,3 +1,4 @@
+
 //
 //  Defaults.swift
 //  Minesweeper
@@ -21,6 +22,7 @@ extension Defaults.Keys {
         static let scale = Key<CGFloat>("scale", default: 1.5)
         static let questions = Key<Bool>("questions", default: false)
         static let safeFirstClick = Key<Bool>("safeFirstClick", default: true)
+        static let alwaysOnTop = Key<Bool>("alwaysOnTop", default: false)
     }
 
     enum Themes {

--- a/Minesweeper/ViewController.swift
+++ b/Minesweeper/ViewController.swift
@@ -1,3 +1,4 @@
+
 //
 //  ViewController.swift
 //  Minesweeper
@@ -65,6 +66,13 @@ class ViewController: NSViewController {
     override func viewDidAppear() {
         if Defaults[.General.toolbarDifficulty] {
             view.window!.subtitle = difficulty
+        }
+
+        // Ensure window level matches the persisted preference when the view appears
+        if Defaults[.General.alwaysOnTop] {
+            view.window?.level = .floating
+        } else {
+            view.window?.level = .normal
         }
     }
 

--- a/Minesweeper/WindowController.swift
+++ b/Minesweeper/WindowController.swift
@@ -71,6 +71,13 @@ class WindowController: NSWindowController {
             zoomButton.target = self
             zoomButton.action = #selector(zoomButtonClicked(_:))
         }
+        
+        // Apply persisted "Always on Top" preference
+        if Defaults[.General.alwaysOnTop] {
+            window?.level = .floating
+        } else {
+            window?.level = .normal
+        }
     }
 
     @objc func zoomButtonClicked(_ sender: Any?) {


### PR DESCRIPTION
## Summary
This PR adds an “Always on Top” option to the Window menu, similar to the Notes app. When enabled, the frontmost window is elevated to the floating level so it stays on top of other apps. For the main Minesweeper window, this preference is persisted across launches. The menu item reflects the current window’s state with a checkmark.

## Changes
- Defaults
  - Added `Defaults[.General.alwaysOnTop]` to persist the preference for the main game window.
- AppDelegate
  - Added Window menu item “Always on Top.”
  - Implemented `toggleAlwaysOnTop(_:)` to toggle the key window’s level.
  - Implemented `NSMenuItemValidation` to update the menu item’s checkmark and enabled state based on the current key window.
- WindowController
  - Applied the persisted `alwaysOnTop` preference when the main window loads.
- ViewController
  - Re-applied the persisted preference in `viewDidAppear()` to ensure consistency when the view/window is recreated.

## Behavior
- Window > Always on Top toggles the key window between `.normal` and `.floating`.
- The menu item is checked when the key window is floating.
- The main game window’s on-top state is saved and restored between launches.
- Other windows (like the Stats window) can be toggled when they’re frontmost, but only the main window’s state is persisted.

## Screenshots
<img width="280" height="365" alt="Screenshot 2025-11-09 at 12 36 57" src="https://github.com/user-attachments/assets/7437f39b-01e5-4d34-a071-58fb602f6bd8" />

## Possible Future Enhancements 
- Add a keyboard shortcut for quick toggling.
- Optionally add “Visible on All Spaces” behavior for persistent visibility across Spaces.